### PR TITLE
Build a first scenario on HCMC after lockdown eased

### DIFF
--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/default.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/default.yml
@@ -1,7 +1,7 @@
 description: BASELINE
 
 time:
-  start: 485 # 29 Apr 2021
+  start: 485 # 29th Apr 2021
   end: 912
 
 country:
@@ -41,14 +41,14 @@ mobility:
       parameters:
         max_effect: .2 # estimated from the Philipines paper
         times:
-          - 485 # 29/04/2021, first community case of COVID-19 detected in Ho Chi Minh City
-          - 505 # 19/05/2021, two new cases first detected after 20 days without any new case
-          - 518 # 01/06/2021, social distancing city-wide under Directive No. 15 of the PM, with Directive No.16 in place at Go Vap District
-          - 546 # 29/06/2021, Directive No.10 of HCMC's authorities in place
-          - 556 # 09/07/2021, Directive No.16 of the PM in place city-wide
-          - 573 # 26/07/2021, curfew from 6PM to 6AM
-          - 601 # 23/08/2021, total lockdown implemented
-          - 640 # 01/10/2021, lockdown started to ease
+          - 485 # 29th April 2021, first community case of COVID-19 detected in Ho Chi Minh City
+          - 505 # 19th May 2021, two new cases first detected after 20 days without any new case
+          - 518 # 01st Jun 2021, social distancing city-wide under Directive No. 15 of the PM, with Directive No.16 in place at Go Vap District
+          - 546 # 29th Jun 2021, Directive No.10 of HCMC's authorities in place
+          - 556 # 09th Jul 2021, Directive No.16 of the PM in place city-wide
+          - 573 # 26th Jul 2021, curfew from 6PM to 6AM
+          - 601 # 23th Aug 2021, total lockdown implemented
+          - 640 # 01st Oct 2021, lockdown started to ease
         values:
           - 0
           - 0.2
@@ -99,45 +99,45 @@ vaccination:
     - age_min: 20
       supply_period_coverage:
         coverage: .006267
-        start_time: 518 # 01 June 2021
-        end_time: 545 # 28 June 2021
+        start_time: 518 # 01st June 2021
+        end_time: 545 # 28th June 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.001289
-        start_time: 545 # 28 June 2021
-        end_time: 556 # 09 July 2021
+        start_time: 545 # 28th June 2021
+        end_time: 556 # 09th July 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.001910
-        start_time: 556 # 09 July 2021
-        end_time: 572 # 25 July 2021
+        start_time: 556 # 09th July 2021
+        end_time: 572 # 25th July 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.0284
-        start_time: 572 # 25 July 2021
-        end_time: 593 # 15 Aug 2021
+        start_time: 572 # 25th July 2021
+        end_time: 593 # 15th Aug 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.0384
-        start_time: 593 # 15 Aug 2021
-        end_time: 610 # 01 Sep 2021
+        start_time: 593 # 15th Aug 2021
+        end_time: 610 # 01st Sep 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.1957
-        start_time: 610 # 01 Sep 2021
-        end_time: 624 # 15 Sep 2021
+        start_time: 610 # 01st Sep 2021
+        end_time: 624 # 15th Sep 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.2915
-        start_time: 624 # 15 Sep 2021
-        end_time: 640 # 01 Oct 2021
+        start_time: 624 # 15th Sep 2021
+        end_time: 640 # 01st Oct 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.2394
-        start_time: 640 # 01 Oct 2021
-        end_time: 654 # 15 Oct 2021
+        start_time: 640 # 01st Oct 2021
+        end_time: 654 # 15th Oct 2021
     - age_min: 20
       supply_period_coverage:
         coverage: 0.2505
-        start_time: 654 # 15 Oct 2021
-        end_time: 670 # 31 Oct 2021
+        start_time: 654 # 15th Oct 2021
+        end_time: 670 # 31st Oct 2021

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -16,7 +16,7 @@ mobility:
       times:
         - 2021-10-01 # lockdown eased
         - 2021-10-02
-        - 2021-10-22
+        - 2021-10-23
         - 2021-11-13
       values:
         - - repeat_prev
@@ -29,8 +29,8 @@ mobility:
       times:
         - 2021-10-01 # lockdown eased
         - 2021-10-02
-        - 2021-11-11
-        - 2021-12-02
+        - 2021-10-23
+        - 2021-11-13
       values:
         - - repeat_prev
         - 0.6

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -1,10 +1,9 @@
 description: >
-  SCENARIO 1: Lockdown returns to 60% on 02nd Oct, 2021 and is eased at 20% every 3 weeks.
-  60% of the population aged 10-20 are fully vaccinated on 15th Dec, 2021,
-  and 90% will be fully vaccinated on 31st Jan, 2022.
-  Vaccination for the 20+ age group continues at the speed of 1 million newly vaccinated people per month
-  for the next two months.
-  Schools reopen on 02nd Jan 2022 at 30% every 2 weeks.
+  SCENARIO 1: Social distancing returns to 60% on 02nd Oct, 2021 and is eased at 20% every 3 weeks.
+  60% and 90% of the population aged 10-20 will be fully vaccinated on 15th Dec 2021 and 31st Jan, 2022, respectively.
+  Vaccination for the 20+ age group continues at the speed of 800000 new fully vaccinated people per month for the next two months,
+  which means approximately 90% of the population this age will be fully vaccinated.
+  Schools start to reopen on 02nd Jan 2022 at 30% every 2 weeks.
 
 time:
   start: 640 # 01st Oct 2021
@@ -68,11 +67,11 @@ vaccination:
       age_max: 19
     - age_min: 20
       supply_period_coverage:
-        coverage: 0.4111
+        coverage: 0.3289
         start_time: 670 # 31st Oct 2021
         end_time: 700 # 30th Nov 2021
     - age_min: 20
       supply_period_coverage:
-        coverage: 0.6982
+        coverage: 0.4901
         start_time: 700 # 30th Nov 2021
         end_time: 731 # 31st Dec 2021

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -40,10 +40,14 @@ mobility:
     school:
       append: false
       times:
+        - 2021-01-01
+        - 2022-01-20
         - 2022-01-02
         - 2021-01-16
         - 2022-01-30
       values:
+        - 0.
+        - 0.1 # universities start to open
         - 0.4
         - 0.7
         - 1.0

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -1,0 +1,79 @@
+description: >
+  SCENARIO 1: Lockdown returns to 60% on 02nd Oct, 2021 and is eased at 20% every 3 weeks.
+  60% of the population aged 10-20 are fully vaccinated on 15th Dec, 2021,
+  and the remaining will be fully vaccinated on 31st Jan, 2022.
+  Vaccination for the 20+ age group continues at the speed of 1 million newly vaccinated people per month
+  until 100% people are vaccinated.
+  Schools reopen on 02nd Jan 2022 at 30% every 2 weeks.
+
+time:
+  start: 640 # 01st Oct 2021
+
+mobility:
+  mixing:
+    other_locations:
+      append: true
+      times:
+        - 2021-10-01 # lockdown eased
+        - 2021-10-02
+        - 2021-10-22
+        - 2021-11-13
+      values:
+        - - repeat_prev
+        - 0.6
+        - 0.4
+        - 0.2
+
+    work:
+      append: true
+      times:
+        - 2021-10-01 # lockdown eased
+        - 2021-10-02
+        - 2021-11-11
+        - 2021-12-02
+      values:
+        - - repeat_prev
+        - 0.6
+        - 0.4
+        - 0.2
+
+    school:
+      append: true
+      times:
+        - 2022-01-02
+        - 2021-01-16
+        - 2022-01-30
+      values:
+        - 0.4
+        - 0.7
+        - 1.0
+
+vaccination:
+  roll_out_components:
+    - supply period coverage:
+        coverage: 0.6
+        start_time: 666 # 27th Oct 2021
+        end_time: 715 # 15th Dec 2021
+      age_min: 10
+      age_max: 19
+    - supply period coverage:
+        coverage: 1.0
+        start_time: 715 # 15th Dec 2021
+        end_time: 762 # 31st Jan 2021
+      age_min: 10
+      age_max: 19
+    - age_min: 20
+      supply_period_coverage:
+        coverage: 0.4111
+        start_time: 670 # 31st Oct 2021
+        end_time: 700 # 30th Nov 2021
+    - age_min: 20
+      supply_period_coverage:
+        coverage: 0.6982
+        start_time: 700 # 30th Nov 2021
+        end_time: 731 # 31st Dec 2021
+    - age_min: 20
+      supply_period_coverage:
+        coverage: 1.0
+        start_time: 731 # 31st Dec 2021
+        end_time: 762 # 31st Jan 2022

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -50,13 +50,13 @@ mobility:
 
 vaccination:
   roll_out_components:
-    - supply period coverage:
+    - supply_period_coverage:
         coverage: 0.6
         start_time: 666 # 27th Oct 2021
         end_time: 715 # 15th Dec 2021
       age_min: 10
       age_max: 19
-    - supply period coverage:
+    - supply_period_coverage:
         coverage: 1.0
         start_time: 715 # 15th Dec 2021
         end_time: 762 # 31st Jan 2021

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -40,14 +40,14 @@ mobility:
     school:
       append: false
       times:
-        - 2021-01-01
-        - 2022-01-20
+        - 2021-05-09 # All schools switched to online learning, school year 2020-2021 ended
+        - 2021-10-20 # Multiple universities started to allow students to come back to finish the degree. Source: Tuoitre.
         - 2022-01-02
         - 2021-01-16
         - 2022-01-30
       values:
         - 0.
-        - 0.1 # universities start to open
+        - 0.1
         - 0.4
         - 0.7
         - 1.0

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -38,7 +38,7 @@ mobility:
         - 0.2
 
     school:
-      append: true
+      append: false
       times:
         - 2022-01-02
         - 2021-01-16

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/params/scenario-1.yml
@@ -1,9 +1,9 @@
 description: >
   SCENARIO 1: Lockdown returns to 60% on 02nd Oct, 2021 and is eased at 20% every 3 weeks.
   60% of the population aged 10-20 are fully vaccinated on 15th Dec, 2021,
-  and the remaining will be fully vaccinated on 31st Jan, 2022.
+  and 90% will be fully vaccinated on 31st Jan, 2022.
   Vaccination for the 20+ age group continues at the speed of 1 million newly vaccinated people per month
-  until 100% people are vaccinated.
+  for the next two months.
   Schools reopen on 02nd Jan 2022 at 30% every 2 weeks.
 
 time:
@@ -40,8 +40,8 @@ mobility:
     school:
       append: false
       times:
-        - 2021-05-09 # All schools switched to online learning, school year 2020-2021 ended
-        - 2021-10-20 # Multiple universities started to allow students to come back to finish the degree. Source: Tuoitre.
+        - 2021-05-09
+        - 2021-10-20
         - 2022-01-02
         - 2021-01-16
         - 2022-01-30
@@ -61,7 +61,7 @@ vaccination:
       age_min: 10
       age_max: 19
     - supply_period_coverage:
-        coverage: 1.0
+        coverage: 0.75
         start_time: 715 # 15th Dec 2021
         end_time: 762 # 31st Jan 2021
       age_min: 10
@@ -76,8 +76,3 @@ vaccination:
         coverage: 0.6982
         start_time: 700 # 30th Nov 2021
         end_time: 731 # 31st Dec 2021
-    - age_min: 20
-      supply_period_coverage:
-        coverage: 1.0
-        start_time: 731 # 31st Dec 2021
-        end_time: 762 # 31st Jan 2022

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/project.py
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/project.py
@@ -9,19 +9,14 @@ from autumn.settings import Region, Models
 import numpy as np
 from autumn.projects.covid_19.calibration import COVID_GLOBAL_PRIORS
 
-from autumn.projects.covid_19.vietnam.ho_chi_minh_city.scenario_builder import get_all_scenario_dicts
+scenario_dir_path = build_rel_path("params/")
 
 # Load and configure model parameters.
 default_path = build_rel_path("params/default.yml")
-
-# scenario_dir_path = build_rel_path("params/")
-# scenario_paths = get_all_available_scenario_paths(scenario_dir_path)
-
+scenario_paths = get_all_available_scenario_paths(scenario_dir_path)
 mle_path = build_rel_path("params/mle-params.yml")
 baseline_params = base_params.update(default_path).update(mle_path, calibration_format=True)
-
-all_scenario_dicts = get_all_scenario_dicts()
-scenario_params = [baseline_params.update(sc_dict) for sc_dict in all_scenario_dicts]
+scenario_params = [baseline_params.update(p) for p in scenario_paths]
 param_set = ParameterSet(baseline=baseline_params, scenarios=scenario_params)
 
 ts_set = TimeSeriesSet.from_file(build_rel_path("timeseries.json"))

--- a/autumn/projects/covid_19/vietnam/ho_chi_minh_city/project.py
+++ b/autumn/projects/covid_19/vietnam/ho_chi_minh_city/project.py
@@ -25,7 +25,6 @@ scenario_params = [baseline_params.update(sc_dict) for sc_dict in all_scenario_d
 param_set = ParameterSet(baseline=baseline_params, scenarios=scenario_params)
 
 ts_set = TimeSeriesSet.from_file(build_rel_path("timeseries.json"))
-n_inflated_weight = 35
 
 targets = []
 for output_name in ["notifications", "infection_deaths", "icu_occupancy", "hospital_occupancy"]:


### PR DESCRIPTION
Change the scenario formation notation from "scenario builder in dictionaries" to "scenario paths". Then, test with writing the first scenario after lockdown is eased on 01st Oct 2021.