### PR TITLE
Revise VoC seeding parameters

### DIFF
--- a/autumn/models/sm_sir/parameters.py
+++ b/autumn/models/sm_sir/parameters.py
@@ -293,6 +293,15 @@ class CrossImmunity(BaseModel):
     check_late_reinfect = validator("late_reinfection", allow_reuse=True)(get_check_prop("late_reinfection"))
 
 
+class VocSeed(BaseModel):
+    start_time: Optional[float]
+    entry_rate: Optional[float]
+    seed_duration: Optional[float]
+
+    check_seed_time = validator("seed_duration", allow_reuse=True)(get_check_non_neg("seed_duration"))
+    check_entry_rate = validator("entry_rate", allow_reuse=True)(get_check_non_neg("entry_rate"))
+
+
 class VocComponent(BaseModel):
     """
     Parameters defining the emergence profile of the Variants of Concerns
@@ -300,22 +309,12 @@ class VocComponent(BaseModel):
 
     starting_strain: bool
     seed_prop: float
-    start_time: Optional[float]
-    entry_rate: Optional[float]
-    seed_duration: Optional[float]
+    new_voc_seed: Optional[VocSeed]
     contact_rate_multiplier: Union[float, None]
     relative_latency: Optional[float]
     immune_escape: float
     cross_protection: Dict[str, CrossImmunity]
     hosp_protection: Optional[float]
-
-    @root_validator(pre=True, allow_reuse=True)
-    def check_times(cls, values):
-        if "seed_duration" in values:
-            assert 0. <= values["seed_duration"], "Seed duration negative"
-        if "entry_rate" in values:
-            assert 0. <= values["entry_rate"], "Entry rate negative"
-        return values
 
     check_immune_escape = validator("immune_escape", allow_reuse=True)(get_check_prop("immune_escape"))
     check_hosp_protection = validator("hosp_protection", allow_reuse=True)(get_check_prop("hosp_protection"))

--- a/autumn/models/sm_sir/strat_processing/strains.py
+++ b/autumn/models/sm_sir/strat_processing/strains.py
@@ -25,7 +25,7 @@ def make_voc_seed_func(entry_rate: float, start_time: float, seed_duration: floa
     return voc_seed_func
 
 
-def seed_vocs(model: CompartmentalModel, voc_params: Dict[str, VocComponent], seed_compartment: str):
+def seed_vocs(model: CompartmentalModel, all_voc_params: Dict[str, VocComponent], seed_compartment: str):
     """
     Use importation flows to seed VoC cases.
 
@@ -37,21 +37,23 @@ def seed_vocs(model: CompartmentalModel, voc_params: Dict[str, VocComponent], se
 
     Args:
         model: The summer model object
-        voc_params: The VoC-related parameters
+        all_voc_params: The VoC-related parameters
         seed_compartment: The compartment that VoCs should be seeded to
 
     """
 
-    for voc_name, voc_values in voc_params.items():
-        voc_seed_func = make_voc_seed_func(
-            voc_values.entry_rate,
-            voc_values.start_time,
-            voc_values.seed_duration
-        )
-        model.add_importation_flow(
-            f"seed_voc_{voc_name}",
-            voc_seed_func,
-            dest=seed_compartment,
-            dest_strata={"strain": voc_name},
-            split_imports=True
-        )
+    for voc_name, this_voc_params in all_voc_params.items():
+        voc_seed_params = this_voc_params.new_voc_seed
+        if voc_seed_params:
+            voc_seed_func = make_voc_seed_func(
+                voc_seed_params.entry_rate,
+                voc_seed_params.start_time,
+                voc_seed_params.seed_duration
+            )
+            model.add_importation_flow(
+                f"seed_voc_{voc_name}",
+                voc_seed_func,
+                dest=seed_compartment,
+                dest_strata={"strain": voc_name},
+                split_imports=True
+            )

--- a/autumn/projects/covid_19/indonesia/indonesia/params/default.yml
+++ b/autumn/projects/covid_19/indonesia/indonesia/params/default.yml
@@ -55,6 +55,7 @@ contact_tracing:
 
 voc_emergence:
   delta:
+
     start_time: 360
     entry_rate: 16.
     seed_duration: 10.

--- a/autumn/projects/sm_sir/bangladesh/bangladesh/params/baseline.yml
+++ b/autumn/projects/sm_sir/bangladesh/bangladesh/params/baseline.yml
@@ -28,16 +28,6 @@ immunity_stratification:
   prop_high_among_immune: .2  # varied in uncertainty
 
 voc_emergence: null
-#  delta:
-#    start_time: 548
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 2.
-#  omicron:
-#    start_time: 2000
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 4.
 
 testing_to_detection:
   assumed_tests_parameter: 1.e-4

--- a/autumn/projects/sm_sir/bangladesh/coxs_bazar/params/baseline.yml
+++ b/autumn/projects/sm_sir/bangladesh/coxs_bazar/params/baseline.yml
@@ -75,16 +75,6 @@ immunity_stratification:
   prop_high_among_immune: .2  # varied in uncertainty
 
 voc_emergence: null
-#  delta:
-#    start_time: 548
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 2.
-#  omicron:
-#    start_time: 2000
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 4.
 
 testing_to_detection:
   assumed_tests_parameter: 1.e-4

--- a/autumn/projects/sm_sir/bangladesh/dhaka/params/baseline.yml
+++ b/autumn/projects/sm_sir/bangladesh/dhaka/params/baseline.yml
@@ -29,16 +29,6 @@ immunity_stratification:
   prop_high_among_immune: .2  # varied in uncertainty
 
 voc_emergence: null
-#  delta:
-#    start_time: 548
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 2.
-#  omicron:
-#    start_time: 2000
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 4.
 
 testing_to_detection:
   assumed_tests_parameter: 1.e-4

--- a/autumn/projects/sm_sir/malaysia/malaysia/params/baseline.yml
+++ b/autumn/projects/sm_sir/malaysia/malaysia/params/baseline.yml
@@ -39,9 +39,7 @@ voc_emergence:
   wild_type:
     starting_strain: true
     seed_prop: 1.
-    start_time: 10000.
-    entry_rate: 0.
-    seed_duration: 0.
+    new_voc_seed: null
     contact_rate_multiplier: null
     immune_escape: 0.
     hosp_protection: 0.
@@ -55,9 +53,10 @@ voc_emergence:
   omicron:
     starting_strain: false
     seed_prop: 0.
-    start_time: 690.
-    entry_rate: 100.
-    seed_duration: 10.
+    new_voc_seed:
+      start_time: 690.
+      entry_rate: 100.
+      seed_duration: 10.
     contact_rate_multiplier: 1.5
     immune_escape: 0.8
     hosp_protection: 0.47

--- a/autumn/projects/sm_sir/myanmar/myanmar/params/baseline.yml
+++ b/autumn/projects/sm_sir/myanmar/myanmar/params/baseline.yml
@@ -28,19 +28,6 @@ immunity_stratification:
   prop_high_among_immune: .2  # varied in uncertainty
 
 voc_emergence: null
-#  delta:
-#    start_time: 365.
-#    entry_rate: 16.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 1.85  # Will be calibrated
-#    # ifr_multiplier: 1.
-#
-#  omicron:
-#    start_time: 2000.
-#    entry_rate: 16.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 3.
-#    # ifr_multiplier: 1.
 
 testing_to_detection:
   assumed_tests_parameter: 1.e-4

--- a/autumn/projects/sm_sir/philippines/national-capital-region/params/baseline.yml
+++ b/autumn/projects/sm_sir/philippines/national-capital-region/params/baseline.yml
@@ -23,16 +23,6 @@ immunity_stratification:
   prop_high_among_immune: .2  # varied in uncertainty
 
 voc_emergence: null
-#  delta:
-#    start_time: 548
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 2.
-#  omicron:
-#    start_time: 2000
-#    entry_rate: 5.
-#    seed_duration: 10.
-#    contact_rate_multiplier: 4.
 
 testing_to_detection:
   assumed_tests_parameter: 1.e-4


### PR DESCRIPTION
Simplify the parameterisation of the VoC seeding parameters, by making the seeding process nullable - so that we don't have to specify for wild type, for example.