### PR TITLE
Fix TruncNormalTarget logpdf calculation

### DIFF
--- a/autumn/tools/calibration/calibration.py
+++ b/autumn/tools/calibration/calibration.py
@@ -35,6 +35,7 @@ from .utils import (
     specify_missing_prior_params,
     draw_independent_samples,
 )
+from .targets import truncnormal_logpdf
 
 ModelBuilder = Callable[[dict,dict], CompartmentalModel]
 
@@ -430,17 +431,8 @@ class Calibration:
                             [w * d for (w, d) in zip(time_weights, squared_distance)]
                         )
                     else:  # this is a truncated normal likelihood
-                        for i in range(len(data)):
-                            ll += (
-                                stats.truncnorm.logpdf(
-                                    x=data[i],
-                                    a=target.trunc_range[0],
-                                    b=target.trunc_range[1],
-                                    loc=model_output[i],
-                                    scale=normal_sd,
-                                )
-                                * time_weights[i]
-                            )
+                        logpdf_arr =  truncnormal_logpdf(data, model_output, target.trunc_range, normal_sd)
+                        ll += (logpdf_arr * time_weights).sum()
                 elif target.loglikelihood_distri == "poisson":
                     for i in range(len(data)):
                         ll += (

--- a/autumn/tools/calibration/targets.py
+++ b/autumn/tools/calibration/targets.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 
 import pandas as pd
 import numpy as np
+from scipy import stats
+
 from summer.utils import ref_times_to_dti
 
 #from autumn.tools.project.timeseries import TimeSeries
@@ -99,3 +101,12 @@ def get_dispersion_priors_for_gaussian_targets(targets: List[BaseTarget]):
         priors.append(prior)
 
     return priors
+
+def truncnormal_logpdf(target_data: np.ndarray, model_output: np.ndarray, trunc_vals: Tuple[float, float], sd: float):
+    """
+    Return the logpdf of a truncated normal target, with scaling transforms
+    according to:
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html
+    """
+    a, b = (trunc_vals[0] - model_output) / sd, (trunc_vals[1] - model_output) / sd
+    return stats.truncnorm.logpdf(x=target_data, a=a, b=b, loc=model_output, scale=sd)


### PR DESCRIPTION
The previous log-likelihood calculation for truncated normal targets seemed just plain wrong - probably due to the weird syntax in scipy.stats;
https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html

Think this should fix it, but @romain-ragonnet can verify
